### PR TITLE
Edit address

### DIFF
--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -1,0 +1,22 @@
+class User::AddressesController < User::BaseController
+  def edit
+    @address = Address.find(params[:id])
+  end
+
+  def update
+    @address = Address.find(params[:id])
+    if @address.update(address_params)
+      flash[:notice] = 'Address has been updated!'
+      redirect_to profile_path
+    else
+      flash.now[:error] = @address.errors.full_messages.to_sentence
+      render :edit
+    end
+  end
+
+  private
+  def address_params
+    params.require(:address).permit(:address, :city, :state, :zip)
+  end
+
+end

--- a/app/controllers/user/base_controller.rb
+++ b/app/controllers/user/base_controller.rb
@@ -1,0 +1,3 @@
+class User::BaseController < ApplicationController
+  before_action :require_user
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -7,5 +7,5 @@ class Address < ApplicationRecord
                         :state,
                         :zip
 
-  enum use: ['home', 'business', 'other', 'address']
+  enum use: ['home', 'business', 'other']
 end

--- a/app/views/user/addresses/edit.html.erb
+++ b/app/views/user/addresses/edit.html.erb
@@ -1,0 +1,14 @@
+<%= form_for(@address, url: "/profile/addresses/#{@address.id}", method: :patch) do |address_fields| %>
+  <%= address_fields.label :address %>
+  <%= address_fields.text_field :address %>
+  <%= address_fields.label :city %>
+  <%= address_fields.text_field :city %>
+  <%= address_fields.label :state %>
+  <%= address_fields.text_field :state %>
+  <%= address_fields.label :zip %>
+  <%= address_fields.text_field :zip %>
+  <%= address_fields.label :use %>
+  <%= address_fields.select :use, ['home', 'business', 'other'] %>
+
+  <%= address_fields.submit 'Submit'%>
+<% end %>

--- a/app/views/user/addresses/edit.html.erb
+++ b/app/views/user/addresses/edit.html.erb
@@ -6,7 +6,7 @@
   <%= address_fields.label :state %>
   <%= address_fields.text_field :state %>
   <%= address_fields.label :zip %>
-  <%= address_fields.text_field :zip %>
+  <%= address_fields.text_field :zip, pattern: "[0-9]{5}" %>
   <%= address_fields.label :use %>
   <%= address_fields.select :use, ['home', 'business', 'other'] %>
 

--- a/app/views/users/_address.html.erb
+++ b/app/views/users/_address.html.erb
@@ -6,7 +6,7 @@
       <h3><%= address.use %></h3>
       <p><%= address.address %></p>
       <p><%= address.city %> <%= address.state %> <%= address.zip %></p>
-      <%= button_to "Edit", edit_user_address_path(@user, address) %>
+      <%= button_to "Edit", "/profile/addresses/#{address.id}/edit", method: :get %>
     </li>
   <% end %>
 </ul>

--- a/app/views/users/_address_form.html.erb
+++ b/app/views/users/_address_form.html.erb
@@ -6,5 +6,5 @@
   <%= address_fields.label :state %>
   <%= address_fields.text_field :state %>
   <%= address_fields.label :zip %>
-  <%= address_fields.text_field :zip %>
+  <%= address_fields.text_field :zip, pattern: "[0-9]{5}" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,9 +29,11 @@ Rails.application.routes.draw do
   get '/profile/orders/:id', to: 'user/orders#show'
   delete '/profile/orders/:id', to: 'user/orders#cancel'
 
-  resources :users do
-    resources :addresses
-  end
+  get '/profile/addresses/:id/edit', to: 'user/addresses#edit'
+  patch '/profile/addresses/:id', to: 'user/addresses#update'
+  # resources :users do
+  #   resources :addresses
+  # end
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#login'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,9 +31,6 @@ Rails.application.routes.draw do
 
   get '/profile/addresses/:id/edit', to: 'user/addresses#edit'
   patch '/profile/addresses/:id', to: 'user/addresses#update'
-  # resources :users do
-  #   resources :addresses
-  # end
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#login'

--- a/spec/features/users/address_edit_spec.rb
+++ b/spec/features/users/address_edit_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe 'A User can Edit their Addresses' do
+  before(:each) do
+    @user_1 = create(:user)
+    @address_1 = create(:address, user_id: @user_1.id)
+    @address_2 = create(:address, user_id: @user_1.id, use: 2)
+    @address_3 = create(:address, user_id: @user_1.id, use: 1)
+  end
+
+  after(:all) do
+    User.all.delete_all
+    Address.all.delete_all
+  end
+
+  it 'shows a pre-populated form to edit an address' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+    visit "/profile"
+
+    within "#address-#{@address_1.id}" do
+      click_button "Edit"
+    end
+
+    expect(current_path).to eq "/profile/addresses/#{@address_1.id}/edit"
+    expect(find_field('Address').value).to eq @address_1.address
+    expect(find_field('City').value).to eq @address_1.city
+    expect(find_field('State').value).to eq @address_1.state
+    expect(find_field('Zip').value).to eq "#{@address_1.zip}"
+    expect(find_field('Use').value).to eq @address_1.use
+  end
+
+  it 'allows me to change my address and shows me the changed address on my profile page' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+    visit "/profile/addresses/#{@address_1.id}/edit"
+
+    fill_in 'Address', with: '456 Nowhere Blvd'
+    fill_in 'City', with: 'Billings'
+    fill_in 'State', with: 'Montana'
+    fill_in 'Zip', with: '80000'
+    select 'business', from: 'Use'
+    click_button 'Submit'
+
+    expect(current_path).to eq '/profile'
+    expect(page).to have_content '456 Nowhere Blvd'
+    expect(page).to have_content 'Billings'
+    expect(page).to have_content 'Montana'
+    expect(page).to have_content 'business'
+    expect(page).to_not have_content @address_1.address
+  end
+
+  it 'throws an error message if a field is nil' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+    visit "/profile/addresses/#{@address_1.id}/edit"
+
+    fill_in 'Address', with: nil
+    click_button 'Submit'
+
+    expect(page).to have_content "Address can't be blank"
+  end
+end


### PR DESCRIPTION
User can now click a button next to each listed address and edit the address.

Future refactor is to move the register user/edit address form into a partial.

12 tests failing due to cart-order-address refactor still to do.
