### PR TITLE
Hide address buttons

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -8,4 +8,8 @@ class Address < ApplicationRecord
                         :zip
 
   enum use: ['home', 'business', 'other']
+
+  def has_shipped_order?
+    !orders.where(status: 'shipped').empty?
+  end
 end

--- a/app/views/users/_address.html.erb
+++ b/app/views/users/_address.html.erb
@@ -6,8 +6,10 @@
       <h3><%= address.use %></h3>
       <p><%= address.address %></p>
       <p><%= address.city %> <%= address.state %> <%= address.zip %></p>
-      <%= button_to "Edit", "/profile/addresses/#{address.id}/edit", method: :get %>
-      <%= button_to "Delete", "/profile/addresses/#{address.id}", method: :delete %>
+      <% unless address.has_shipped_order? %>
+        <%= button_to "Edit", "/profile/addresses/#{address.id}/edit", method: :get %>
+        <%= button_to "Delete", "/profile/addresses/#{address.id}", method: :delete %>
+      <% end %>
     </li>
   <% end %>
 </ul>

--- a/spec/features/users/addresses_on_profile_spec.rb
+++ b/spec/features/users/addresses_on_profile_spec.rb
@@ -6,11 +6,15 @@ describe 'All addresses for a user are listed on their Address Index page' do
     @address_1 = create(:address, user_id: @user_1.id)
     @address_2 = create(:address, user_id: @user_1.id, use: 2)
     @address_3 = create(:address, user_id: @user_1.id, use: 1)
+    @megan = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+    @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20.25, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
   end
 
   after(:all) do
     User.all.delete_all
     Address.all.delete_all
+    Merchant.all.delete_all
+    Item.all.delete_all
   end
 
   describe 'as a logged in user' do
@@ -80,6 +84,37 @@ describe 'All addresses for a user are listed on their Address Index page' do
       @user_1.addresses.each do |address|
         expect(page).to have_button("Delete")
       end
+    end
+
+    it 'hides the edit and delete buttons if an address is in a shipped order' do
+      order_1 = @user_1.orders.create!(address_id: @address_1.id, status: 'shipped')
+      order_1.order_items.create!(item: @ogre, price: @ogre.price, quantity: 2)
+
+      order_2 = @user_1.orders.create!(address_id: @address_2.id, status: 'pending')
+      order_2.order_items.create!(item: @ogre, price: @ogre.price, quantity: 1)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+      visit "/profile"
+
+      within "#address-#{@address_1.id}" do
+        expect(page).to have_content(@address_1.use)
+        expect(page).to have_content(@address_1.address)
+        expect(page).to have_content(@address_1.city)
+        expect(page).to have_content(@address_1.state)
+        expect(page).to_not have_button "Edit"
+        expect(page).to_not have_button "Delete"
+      end
+
+      within "#address-#{@address_2.id}" do
+        expect(page).to have_button "Edit"
+        expect(page).to have_button "Delete"
+      end
+
+      within "#address-#{@address_3.id}" do
+        expect(page).to have_button "Edit"
+        expect(page).to have_button "Delete"
+      end
+
     end
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -18,11 +18,23 @@ RSpec.describe Address do
       @user = create(:user)
       @address_1 = create(:address, user_id: @user.id)
       @address_2 = create(:address, user_id: @user.id, use: 1)
+
+      @megan = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20.25, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 5 )
+
+      @order_1 = @user.orders.create!(address_id: @address_1.id, status: 'shipped')
+      @order_1.order_items.create!(item: @ogre, price: @ogre.price, quantity: 2)
+
     end
 
     it 'names the first address as home' do
       expect(@address_1.use).to eq('home')
       expect(@address_2.use).to_not eq('home')
+    end
+
+    it 'returns boolean for has_shipped_order?' do
+      expect(@address_1.has_shipped_order?).to be_truthy
+      expect(@address_2.has_shipped_order?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
If a user's order is 'shipped' both the edit and delete buttons for the associated address are hidden.

All tests passing 99.8% coverage